### PR TITLE
use "peerDependencies" instead of "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "author": "Joel Einbinder",
   "license": "MIT",
-  "dependencies": {
-    "playwright": "^0.12.1"
+  "peerDependencies": {
+    "playwright": "1.x"
   }
 }


### PR DESCRIPTION
Hi,

Playwright was recently updated to `1.x` and projects using `1.x` version started to download playwright twice. Can we switch to `peerDependencies` and release updated package to npm? (1.x API seems to be compatible with 0.12)