### PR TITLE
Optional headless/headful, custom launch options and device emulation/custom context options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,40 @@
 # karma-playwright-launcher
 
-Provides three browsers to [Karma](https://karma-runner.github.io/): 'Firefox', 'Chromium', 'WebKit'
+Provides six browsers to [Karma](https://karma-runner.github.io/):
+
+* `Chromium`
+* `ChromiumHeadless`
+* `Firefox`
+* `FirefoxHeadless`
+* `WebKit`
+* `WebKitHeadless`
+
+The "real" Chrome, Edge or custom versions of the browsers can be configured by providing
+[`launchOptions`](https://playwright.dev/docs/api/class-browsertype#browsertypelaunchoptions) in your Karma
+configuration. The browsers must be downloaded and installed manually.
+
+```js
+    ...
+    customLaunchers: {
+        HeadlessEdge: {
+            base: 'HeadlessChromium',
+            displayName: 'HeadlessEdge',
+            launchOptions: {
+                channel: 'msedge'
+            }
+        }
+    },
+
+    browsers: [
+        'HeadlessChromium',
+        'HeadlessEdge',
+        'HeadlessFirefox',
+        'HeadlessWebKit',
+    ],
+    ...
+```
+
+Valid values for the `channel` option are: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`,
+`msedge-beta`, `msedge-dev`, `msedge-canary`.
 
 Powered by [playwright](https://github.com/microsoft/playwright).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,34 @@ Provides six browsers to [Karma](https://karma-runner.github.io/):
 
 Powered by [Playwright](https://github.com/microsoft/playwright).
 
+## Device emulation
+
+Playwright supports [device emulation](https://playwright.dev/docs/emulation) to control various aspects of the browser.
+This is probably more important for E2E testing than unit testing, but some configuration (like locale and timezone) may
+be useful for unit testing as well.
+
+You can control these settings by providing `device` and/or [`contextOptions`](https://playwright.dev/docs/next/api/class-browser#browsernewcontextoptions) in `karma.conf.js`.
+
+```js
+    ...
+    customLaunchers: {
+        iPhone: {
+            base: 'WebKit',
+            displayName: 'iPhone',
+            device: 'iPhone 6',
+            contextOptions: {
+                locale: 'sv-SE'
+            }
+        }
+    },
+
+    browsers: [
+        'iPhone',
+    ],
+    ...
+```
+
+
 ## Non-bundled browsers
 
 The "real" Chrome, Edge or custom versions of the browsers can be configured by providing

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ configuration. The browsers must be downloaded and installed manually.
 ```js
     ...
     customLaunchers: {
-        HeadlessEdge: {
-            base: 'HeadlessChromium',
-            displayName: 'HeadlessEdge',
+        EdgeHeadless: {
+            base: 'ChromiumHeadless',
+            displayName: 'EdgeHeadless',
             launchOptions: {
                 channel: 'msedge'
             }
@@ -59,10 +59,10 @@ configuration. The browsers must be downloaded and installed manually.
     },
 
     browsers: [
-        'HeadlessChromium',
-        'HeadlessEdge',
-        'HeadlessFirefox',
-        'HeadlessWebKit',
+        'ChromiumHeadless',
+        'EdgeHeadless',
+        'FirefoxHeadless',
+        'WebKitHeadless',
     ],
     ...
 ```
@@ -79,3 +79,31 @@ in order to force a specific version. [npm](https://github.com/npm/rfcs/blob/lat
 support this yet, but there is a [package](https://www.npmjs.com/package/npm-force-resolutions) available that might work.
 
 See the [Playwright Release Notes](https://playwright.dev/versions/) for what browsers are bundled.
+
+## History
+
+### 0.3.0
+
+* Martin Blom: Now uses the Karma decorators and event handling instead of a custom class.
+
+### 0.2.1
+
+* Martin Blom: Fixed typo. Bumped rev.
+
+### 0.2.0
+
+* Martin Blom: Publish forked package as `@onslip/karma-playwright-launcher`.
+* Martin Blom: Added device emulation support.
+
+### 0.1.1
+
+* Martin Blom: Relaxed required playwright version and added note about pinning.
+
+### 0.1.0
+
+* Martin Blom: Provide both headful and headless browsers, support custom launch options.
+* Emil Björklund: Add guard for missing browser.
+
+### 0.0.1
+
+* Joel Einbinder/Endy Jasmi: Original version, published as `karma-playwright-launcher`.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Provides six browsers to [Karma](https://karma-runner.github.io/):
 * `WebKit`
 * `WebKitHeadless`
 
+Powered by [Playwright](https://github.com/microsoft/playwright).
+
+## Non-bundled browsers
+
 The "real" Chrome, Edge or custom versions of the browsers can be configured by providing
 [`launchOptions`](https://playwright.dev/docs/api/class-browsertype#browsertypelaunchoptions) in your Karma
 configuration. The browsers must be downloaded and installed manually.
@@ -37,4 +41,12 @@ configuration. The browsers must be downloaded and installed manually.
 Valid values for the `channel` option are: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`,
 `msedge-beta`, `msedge-dev`, `msedge-canary`.
 
-Powered by [playwright](https://github.com/microsoft/playwright).
+## Older browsers
+
+Each Playwright release bundles specific versions of Chromium, Firefox and WebKit. If you use
+[Yarn](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/) or
+[pnpm](https://pnpm.io/package_json#pnpmoverrides), it's possible you may lock the version of the `playwright` package
+in order to force a specific version. [npm](https://github.com/npm/rfcs/blob/latest/accepted/0036-overrides.md) does not
+support this yet, but there is a [package](https://www.npmjs.com/package/npm-force-resolutions) available that might work.
+
+See the [Playwright Release Notes](https://playwright.dev/versions/) for what browsers are bundled.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @onslip/karma-playwright-launcher
 
-[![npm version](https://badge.fury.io/js/%40onslip%karma-playwright-launcher.svg)](https://badge.fury.io/js/%40onslip%karma-playwright-launcher)
+[![npm version](https://badge.fury.io/js/%40onslip%2Fkarma-playwright-launcher.svg)](https://badge.fury.io/js/%40onslip%2Fkarma-playwright-launcher)
 
 Provides six browsers to [Karma](https://karma-runner.github.io/):
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# karma-playwright-launcher
+# @onslip/karma-playwright-launcher
+
+[![npm version](https://badge.fury.io/js/%40onslip%karma-playwright-launcher.svg)](https://badge.fury.io/js/%40onslip%karma-playwright-launcher)
 
 Provides six browsers to [Karma](https://karma-runner.github.io/):
 
@@ -37,7 +39,6 @@ You can control these settings by providing `device` and/or [`contextOptions`](h
     ],
     ...
 ```
-
 
 ## Non-bundled browsers
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const {webkit, chromium, firefox} = require('playwright');
+const {devices, webkit, chromium, firefox} = require('playwright');
 
 class PwBrowser extends EventEmitter {
     /**
@@ -20,7 +20,7 @@ class PwBrowser extends EventEmitter {
     async start(url) {
         this._browser = await this._browserType.launch({ headless: this._headless, ...this._args.launchOptions });
         this._browser.on('close', () => this.emit('done'));
-        const page = await this._browser.newPage();
+        const page = await this._browser.newPage({ ...devices[this._args.device], ...this._args.contextOptions });
         await page.goto(`${url}?id=${this.id}&displayName=${encodeURIComponent(this.displayName || this.name)}`);
     }
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ class PwBrowser extends EventEmitter {
     }
 
     async forceKill() {
-        await this._browser.close();
+        if (this._browser) {
+            await this._browser.close();
+        }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-playwright-launcher",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Karma launcher plugin powered by playwright.",
   "repository": "github:JoelEinbinder/karma-playwright-launcher",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "author": "Joel Einbinder",
   "license": "MIT",
   "dependencies": {
-    "playwright": "^0.12.1"
+    "playwright": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onslip/karma-playwright-launcher",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Karma launcher plugin powered by playwright.",
   "repository": "github:Onslip/karma-playwright-launcher",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-playwright-launcher",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Karma launcher plugin powered by playwright.",
   "repository": "github:JoelEinbinder/karma-playwright-launcher",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "karma-playwright-launcher",
+  "name": "@onslip/karma-playwright-launcher",
   "version": "0.2.0",
   "description": "Karma launcher plugin powered by playwright.",
-  "repository": "github:JoelEinbinder/karma-playwright-launcher",
+  "repository": "github:Onslip/karma-playwright-launcher",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -13,6 +13,7 @@
     "playwright"
   ],
   "author": "Joel Einbinder",
+  "contributors": [ "Martin Blom <martin.blom@onslip.com>" ],
   "license": "MIT",
   "dependencies": {
     "playwright": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-playwright-launcher",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Karma launcher plugin powered by playwright.",
   "repository": "github:JoelEinbinder/karma-playwright-launcher",
   "main": "index.js",
@@ -15,6 +15,6 @@
   "author": "Joel Einbinder",
   "license": "MIT",
   "dependencies": {
-    "playwright": "^1.10.0"
+    "playwright": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onslip/karma-playwright-launcher",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Karma launcher plugin powered by playwright.",
   "repository": "github:Onslip/karma-playwright-launcher",
   "main": "index.js",


### PR DESCRIPTION
Wow this launcher is amazing! Can't believe nobody is using it.

Anyway, for our own usage, I've updated it some. I could publish the fork on NPM but I kind of hope you will accept the patches an push an update to your own package. We're specifying `"Onslip/karma-playwright-launcher#v0.2.0"` in our `package.json` files and can continue to do so for a while.

This PR

1. Bumps the `playwright` dependency to `^1`.
2. Provides both "normal" and headless browsers.
3. Allow users to configure `LaunchOptions` (to drive real Chrome or Edge browsers, for instance).
4. Allow users to specify a device type for emulation or to override the `BrowserContextOptions`.
5. Respects `displayName`.
6. Includes Emil Björklunds crash fix in `forceKill()` (from Sydsvenskan/karma-playwright-launcher.git).
